### PR TITLE
fixed multitenant-project-template.yaml

### DIFF
--- a/template/multitenant-project-template.yaml
+++ b/template/multitenant-project-template.yaml
@@ -68,15 +68,15 @@ objects:
     - Ingress
 # Set resource quotas per project
 # https://docs.openshift.com/container-platform/4.6/applications/quotas/quotas-setting-per-project.html
-apiVersion: v1
-kind: ResourceQuota
-metadata:
-  name: compute
-spec:
-  hard:
-    requests.cpu: 4
-    requests.memory: 24Gi
-    limits.memory: 24Gi
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: compute
+  spec:
+    hard:
+      requests.cpu: "4"
+      requests.memory: 24Gi
+      limits.memory: 24Gi
 # Set limit range so that pods fit within quota
 # https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html
 - apiVersion: v1


### PR DESCRIPTION
I added the dash before apiVersion and increased the indentation as needed. It works now when I use it in OCP.